### PR TITLE
Change asset name to reflect model code

### DIFF
--- a/StyleTransfer/StyleTransferViewController.swift
+++ b/StyleTransfer/StyleTransferViewController.swift
@@ -12,7 +12,7 @@ import CoreML
 
 class StyleTransferViewController: ViewController {
   
-    private let assetName:String = "StyleTransfer.mlmodel"
+    private let assetName:String = "StyleTransfer"
     private var myStyleTransfer:StyleTransfer! = StyleTransfer()
     private var selectedImage: UIImage! = nil
   


### PR DESCRIPTION
Changed asset name from StyleTransfer.mlmodel --> StyleTransfer to reflect the model code in https://github.com/skafos/TuriStyleTransfer/blob/164056746-new-sdk/style_transfer.ipynb